### PR TITLE
Support FutuOpenD protocal encryption

### DIFF
--- a/config/config_template.ini
+++ b/config/config_template.ini
@@ -4,6 +4,7 @@ Port = 11111
 WebSocketPort = 33333
 WebSocketKey = 3e1d3hu5i4kf8s9d
 TrdEnv = SIMULATE
+RsaPrivateKey = C:\futu_algo\config\rsa.key
 
 [FutuOpenD.Credential]
 Username = johndoe

--- a/engines/trading_engine.py
+++ b/engines/trading_engine.py
@@ -18,6 +18,7 @@
 
 import itertools
 import json
+import pathlib
 import platform
 import subprocess
 from datetime import date, datetime, timedelta
@@ -30,7 +31,7 @@ from futu import AccumulateFilter, AuType, Currency, KLType, KL_FIELD, Market, M
     RET_ERROR, RET_OK, \
     SecurityReferenceType, \
     SecurityType, \
-    SimpleFilter, SortDir, StockField, SubType, TradeDateMarket, TrdEnv
+    SimpleFilter, SortDir, StockField, SubType, TradeDateMarket, TrdEnv, SysConfig
 
 import engines
 from engines import DataProcessingInterface, HKEXInterface, YahooFinanceInterface
@@ -46,6 +47,13 @@ class FutuTrade:
         self.config = config
         self.default_logger = logger.get_logger("futu_trade")
         self.__init_futu_client()
+
+        rsa_private_key = self.config['FutuOpenD.Config'].get('RsaPrivateKey')
+        if rsa_private_key and pathlib.Path(rsa_private_key).is_file():
+            # Setting protocol encryption globally
+            SysConfig.enable_proto_encrypt(True)
+            SysConfig.set_init_rsa_file(rsa_private_key)
+
         self.quote_ctx = OpenQuoteContext(host=self.config['FutuOpenD.Config'].get('Host'),
                                           port=self.config['FutuOpenD.Config'].getint('Port'))
         self.trade_ctx = OpenHKTradeContext(host=self.config['FutuOpenD.Config'].get('Host'),


### PR DESCRIPTION
When the listening address is not local, a private key must be configured to use the trading interface. 
https://openapi.futunn.com/futu-api-doc/en/opend/opend-cmd.html#149

Enable FutuOpenD encryption protocol when a RSA key is provided in config.ini
Futu API: https://openapi.futunn.com/futu-api-doc/en/ftapi/init.html#7910
